### PR TITLE
Decode '+' sign in URL

### DIFF
--- a/src/library/Utilities/Location.js
+++ b/src/library/Utilities/Location.js
@@ -31,7 +31,7 @@ class Location extends Chunk {
 		}).filter(p => {
 			return p.length >= 2;
 		}).map(p => {
-			return p.map(seg => decodeURIComponent(seg));
+			return p.map(seg => decodeURIComponent(seg.replace(/\+/g, ' ')));
 		}).forEach(p => {
 			this.add.apply(this, p);
 		});


### PR DESCRIPTION
Search forms submit with a '+' in place of spaces. This commit
makes the Location utility decode the '+' back into a space so
that the API can be queried correctly.

Signed-off-by: Zach-Button <zach@searchspring.com>