### PR TITLE
Fix autocomplete widget IE compatibility

### DIFF
--- a/gulpfile.webpack.js
+++ b/gulpfile.webpack.js
@@ -19,18 +19,9 @@ function getWebpackConf(_path) {
 					exclude: /node_modules/,
 					loader: 'babel',
 					query: {
+						presets: ['es2015'],
 						plugins: [
-							['transform-react-jsx', { pragma: 'm' }],
-							['transform-es2015-arrow-functions'],
-							['transform-es2015-block-scoped-functions'],
-							['transform-es2015-block-scoping'],
-							['transform-es2015-classes'],
-							// ['transform-es2015-object-super'],
-							['transform-es2015-destructuring'],
-							['transform-es2015-parameters'],
-							['transform-es2015-shorthand-properties'],
-							['transform-es2015-spread'],
-							['transform-es2015-template-literals'],
+							['transform-react-jsx', { pragma: 'm' }]
 						]
 					},
 				},


### PR DESCRIPTION
The autocomplete widget has variable object keys in its source.
The babel plugins used were not transpiling this down
to ES5. This commit adds the babel es2015 preset, which we
can use since we're bundling babel-polyfill now. This preset
corrects this issue.