### PR TITLE
Changes to support sites that also try to load babel-pollyfil

### DIFF
--- a/src/library/Services/Autocompleter.js
+++ b/src/library/Services/Autocompleter.js
@@ -6,7 +6,7 @@ let Searcher = require('./Searcher');
 class Autocompleter extends Requester {
 	constructor(defaultParams, config) {
 		config = Object.assign({
-			apiProtocol: '//',
+			apiProtocol: (window.location.protocol == "https:" ? 'https://' : 'http://'),
 			apiHost: 'autocomplete2.searchspring.net',
 			apiEndpoint: '/'
 		}, config || {});

--- a/src/library/Services/Searcher.js
+++ b/src/library/Services/Searcher.js
@@ -11,7 +11,7 @@ class Searcher extends Requester {
 		}, defaultParams || {});
 
 		config = Object.assign({}, {
-			apiProtocol: '//',
+			apiProtocol: (window.location.protocol == "https:" ? 'https://' : 'http://'),
 			apiHost: 'api.searchspring.net',
 			apiEndpoint: '/api/search/search.json'
 		}, config || {});

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,9 @@
-require('babel-polyfill');
+try {
+	require('babel-polyfill');
+} catch(e) {
+	// ignore
+	console.log('Unable to load babel-polyfill');
+}
 
 require('styles/index.scss');
 


### PR DESCRIPTION
 (BigCommerce appears to be doing this now in their templates, appearing in their bundle.js files).

+ Adding try/catch around require('babel-polyfil') - which should work as long as we load after the other script that loads polyfill
+ Making the Search API and Autocomplete API requests always occur over http/https for easier local testing